### PR TITLE
refactor rotlib test

### DIFF
--- a/tests/test_RotamerEnsemble.py
+++ b/tests/test_RotamerEnsemble.py
@@ -328,9 +328,22 @@ def test_from_trajectory():
 
 def test_to_rotlib():
 
+    # Generate rotamer library from trajectory
     RE = chilife.RotamerEnsemble.from_trajectory(traj, 230, burn_in=0)
     RE.to_rotlib('Test')
+    
+    # Build rotamer ensemble from new rotamer library
     RE2 = chilife.RotamerEnsemble('TRP', rotlib='Test')
+
+    # Load new rotamer libary, then delete file
+    with np.load(f"Test_rotlib.npz", allow_pickle=True) as f:
+        rotlib_test = dict(f)
+    os.remove('Test_rotlib.npz')
+
+    # Load previously saved reference rotamer libary
+    with np.load(f"test_data/Test_rotlib.npz", allow_pickle=True) as f:
+        rotlib_reference = dict(f)
+
     assert RE2.res == 'TRP'
     assert len(RE2) == 10
 
@@ -345,15 +358,7 @@ def test_to_rotlib():
                                                    [ -69.90840475,  -39.25944367],
                                                    [ -69.90840475,  161.67407146]])
 
-    with np.load(f"test_data/Test_rotlib.npz", allow_pickle=True) as f:
-        ans = dict(f)
 
-    with np.load(f"Test_rotlib.npz", allow_pickle=True) as f:
-        test = dict(f)
-
-    os.remove('Test_rotlib.npz')
-
-    np.testing.assert_almost_equal(test['coords'], ans['coords'], decimal=6)
-    np.testing.assert_almost_equal(test['weights'], ans['weights'], decimal=6)
-    np.testing.assert_almost_equal(test['dihedrals'], ans['dihedrals'], decimal=6)
-
+    np.testing.assert_almost_equal(rotlib_test['coords'], rotlib_reference['coords'], decimal=6)
+    np.testing.assert_almost_equal(rotlib_test['weights'], rotlib_reference['weights'], decimal=6)
+    np.testing.assert_almost_equal(rotlib_test['dihedrals'], rotlib_reference['dihedrals'], decimal=6)


### PR DESCRIPTION
Refactor `test_RotamerEnsemble.py::test_to_rotlib` such that it doesn't leave temp files in case an assertion fails.