### PR TITLE
Respect write_spin_centers parameter for PDB HEADER and TER strings

### DIFF
--- a/src/chilife/io.py
+++ b/src/chilife/io.py
@@ -749,7 +749,6 @@ def write_labels(pdb_file: TextIO, *args: sl.SpinLabel,
         if not np.any(label.spin_centers):
             continue
 
-        pdb_file.write(f"HEADER {label.name}_density\n")
         spin_centers = np.atleast_2d(label.spin_centers)
 
         if KDE and len(spin_centers) > 5:
@@ -767,6 +766,7 @@ def write_labels(pdb_file: TextIO, *args: sl.SpinLabel,
             vals = label.weights
 
         if write_spin_centers:
+            pdb_file.write(f"HEADER {label.name}_density\n")
             norm_weights = vals / vals.max()
             [
                 pdb_file.write(
@@ -784,8 +784,8 @@ def write_labels(pdb_file: TextIO, *args: sl.SpinLabel,
                 )
                 for i in range(len(norm_weights))
             ]
+            pdb_file.write("TER\n")
 
-        pdb_file.write("TER\n")
 
 
 def write_atoms(file: TextIO,


### PR DESCRIPTION
Previously, the PDB HEADER and TER statements written at the end of PDB files by xl.save() were not controlled by the write_spin_centers boolean parameter. This caused empty PDB blocks to be written even when write_spin_centers=False, leading to malformed PDB files that might cause issues for other progrmas, such as warnings thrown out by PyMOL. This pull request fixes the issue by placing the code that writes HEADER and TER statements under the same conditional check for write_spin_centers. Now these statements are only written when spin centers are actually being saved to the file.
